### PR TITLE
docs(tools): fix stale proxy connected_account_id docstring [PLEN-2345]

### DIFF
--- a/src/composio_client/resources/tools.py
+++ b/src/composio_client/resources/tools.py
@@ -384,7 +384,7 @@ class ToolsResource(SyncAPIResource):
           body: The request body (for POST, PUT, and PATCH requests)
 
           connected_account_id: The ID of the connected account to use for authentication. Required
-              unless ``custom_connection_data`` is provided — the proxy endpoint
+              unless ``custom_connection_data`` is provided. The proxy endpoint
               returns 400 ``ExternalProxy_MissingAuthContext`` when both are
               omitted.
 
@@ -791,7 +791,7 @@ class AsyncToolsResource(AsyncAPIResource):
           body: The request body (for POST, PUT, and PATCH requests)
 
           connected_account_id: The ID of the connected account to use for authentication. Required
-              unless ``custom_connection_data`` is provided — the proxy endpoint
+              unless ``custom_connection_data`` is provided. The proxy endpoint
               returns 400 ``ExternalProxy_MissingAuthContext`` when both are
               omitted.
 

--- a/src/composio_client/resources/tools.py
+++ b/src/composio_client/resources/tools.py
@@ -383,8 +383,10 @@ class ToolsResource(SyncAPIResource):
 
           body: The request body (for POST, PUT, and PATCH requests)
 
-          connected_account_id: The ID of the connected account to use for authentication (if not provided, will
-              use the default account for the project)
+          connected_account_id: The ID of the connected account to use for authentication. Required
+              unless ``custom_connection_data`` is provided — the proxy endpoint
+              returns 400 ``ExternalProxy_MissingAuthContext`` when both are
+              omitted.
 
           parameters: Additional HTTP headers or query parameters to include in the request
 
@@ -788,8 +790,10 @@ class AsyncToolsResource(AsyncAPIResource):
 
           body: The request body (for POST, PUT, and PATCH requests)
 
-          connected_account_id: The ID of the connected account to use for authentication (if not provided, will
-              use the default account for the project)
+          connected_account_id: The ID of the connected account to use for authentication. Required
+              unless ``custom_connection_data`` is provided — the proxy endpoint
+              returns 400 ``ExternalProxy_MissingAuthContext`` when both are
+              omitted.
 
           parameters: Additional HTTP headers or query parameters to include in the request
 


### PR DESCRIPTION
# Description

PLEN-2345. The proxy endpoint stopped accepting empty auth context — it now returns 400 `ExternalProxy_MissingAuthContext` when neither `connected_account_id` nor `custom_connection_data` is provided ([hermes#9582](https://github.com/ComposioHQ/hermes/pull/9582), shipped 2026-04-24 as part of the PLEN-2166 security fix).

The stale docstring claim — _"if not provided, will use the default account for the project"_ — no longer matches runtime behavior. Callers following the docstring hit an undocumented 400 in production (broke custom Salesforce / Databricks / Google Docs tools).

Updates both the sync (`ToolsResource.proxy`) and async (`AsyncToolsResource.proxy`) variants in `src/composio_client/resources/tools.py`.

# How did I test this PR

- **Diff inspection** — verified both sync (line 386-389) and async (line 793-796) docstrings now read identically.
- **Generated-code policy** — `CONTRIBUTING.md` confirms manual patches in generated files are persisted across regenerations.
- No code changes — docstring-only.

## CI status

- ✅ `build` — pass
- ⚠️ `lint`, `test` — **pre-existing failures on `main`** (commit `36e16687`), unrelated to this PR:
  - `lint` flags `[no-redef]` errors in the generated `src/composio_client/types/trigger_instance_list_active_response.py` (5 fields).
  - `test` fails on `tests/api_resources/tool_router/test_session.py` because the fixture sends a `workbench.sandbox_size` property that the OpenAPI mock-server schema rejects (`E3009 Unknown property`).
  Both reproduce on `main` so they were not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)