### PR TITLE
fix: preserve trigger account identifiers in Python

### DIFF
--- a/src/composio_client/types/trigger_instance_list_active_response.py
+++ b/src/composio_client/types/trigger_instance_list_active_response.py
@@ -26,7 +26,7 @@ class Item(BaseModel):
     connected_account_uuid: str
     """UUID of the connected account this trigger is associated with"""
 
-    connected_account_id: str = FieldInfo(alias="connectedAccountId")
+    deprecated_connected_account_id: str = FieldInfo(alias="connectedAccountId")
     """DEPRECATED: This parameter will be removed in a future version.
 
     Please use connected_account_id instead.
@@ -35,7 +35,7 @@ class Item(BaseModel):
     disabled_at: Optional[str] = None
     """ISO 8601 timestamp when the trigger instance was disabled, if applicable"""
 
-    disabled_at: Optional[str] = FieldInfo(alias="disabledAt", default=None)
+    deprecated_disabled_at: Optional[str] = FieldInfo(alias="disabledAt", default=None)
     """DEPRECATED: This parameter will be removed in a future version.
 
     Please use disabled_at instead.
@@ -53,13 +53,13 @@ class Item(BaseModel):
     trigger_name: str
     """Name of the trigger"""
 
-    trigger_config: Dict[str, Optional[object]] = FieldInfo(alias="triggerConfig")
+    deprecated_trigger_config: Dict[str, Optional[object]] = FieldInfo(alias="triggerConfig")
     """DEPRECATED: This parameter will be removed in a future version.
 
     Please use trigger_config instead.
     """
 
-    trigger_name: str = FieldInfo(alias="triggerName")
+    deprecated_trigger_name: str = FieldInfo(alias="triggerName")
     """DEPRECATED: This parameter will be removed in a future version.
 
     Please use trigger_name instead.
@@ -68,7 +68,7 @@ class Item(BaseModel):
     updated_at: str
     """ISO 8601 timestamp when the trigger instance was updated"""
 
-    updated_at: str = FieldInfo(alias="updatedAt")
+    deprecated_updated_at: str = FieldInfo(alias="updatedAt")
     """DEPRECATED: This parameter will be removed in a future version.
 
     Please use updated_at instead.

--- a/stainless.yml
+++ b/stainless.yml
@@ -1,0 +1,42 @@
+openapi:
+  transforms:
+    - command: merge
+      reason: "Keep the deprecated connected account identifier distinct in Python"
+      args:
+        target: "$.paths['/api/v3.1/trigger_instances/active'].get.responses['200'].content['application/json'].schema.properties.items.items.properties.connectedAccountId"
+        value:
+          x-stainless-naming:
+            python:
+              property_name: deprecated_connected_account_id
+    - command: merge
+      reason: "Keep the deprecated disabled timestamp distinct in Python"
+      args:
+        target: "$.paths['/api/v3.1/trigger_instances/active'].get.responses['200'].content['application/json'].schema.properties.items.items.properties.disabledAt"
+        value:
+          x-stainless-naming:
+            python:
+              property_name: deprecated_disabled_at
+    - command: merge
+      reason: "Keep the deprecated trigger config distinct in Python"
+      args:
+        target: "$.paths['/api/v3.1/trigger_instances/active'].get.responses['200'].content['application/json'].schema.properties.items.items.properties.triggerConfig"
+        value:
+          x-stainless-naming:
+            python:
+              property_name: deprecated_trigger_config
+    - command: merge
+      reason: "Keep the deprecated trigger name distinct in Python"
+      args:
+        target: "$.paths['/api/v3.1/trigger_instances/active'].get.responses['200'].content['application/json'].schema.properties.items.items.properties.triggerName"
+        value:
+          x-stainless-naming:
+            python:
+              property_name: deprecated_trigger_name
+    - command: merge
+      reason: "Keep the deprecated updated timestamp distinct in Python"
+      args:
+        target: "$.paths['/api/v3.1/trigger_instances/active'].get.responses['200'].content['application/json'].schema.properties.items.items.properties.updatedAt"
+        value:
+          x-stainless-naming:
+            python:
+              property_name: deprecated_updated_at

--- a/tests/api_resources/test_trigger_instances.py
+++ b/tests/api_resources/test_trigger_instances.py
@@ -13,12 +13,65 @@ from composio_client.types import (
     TriggerInstanceUpsertResponse,
     TriggerInstanceListActiveResponse,
 )
+from composio_client.types.trigger_instance_list_active_response import Item
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
 
 class TestTriggerInstances:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    def test_list_active_response_preserves_canonical_and_deprecated_fields(self) -> None:
+        payload_item = Item(
+            id="ti_123",
+            connected_account_id="ca_nanoid",
+            connected_account_uuid="uuid-123",
+            connectedAccountId="legacy-account-id",
+            trigger_name="CANONICAL_TRIGGER",
+            triggerName="LEGACY_TRIGGER",
+            trigger_config={"canonical": True},
+            triggerConfig={"legacy": True},
+            state={},
+            updated_at="2026-07-29T00:00:00Z",
+            updatedAt="2025-07-29T00:00:00Z",
+            disabled_at=None,
+            disabledAt="2025-07-29T00:00:00Z",
+            user_id="user_123",
+            version="latest",
+        )
+        response = TriggerInstanceListActiveResponse(
+            current_page=1,
+            items=[payload_item],
+            total_items=1,
+            total_pages=1,
+            next_cursor=None,
+        )
+
+        item = response.items[0]
+        assert item.connected_account_id == "ca_nanoid"
+        assert item.connected_account_uuid == "uuid-123"
+        assert item.deprecated_connected_account_id == "legacy-account-id"
+        assert item.trigger_name == "CANONICAL_TRIGGER"
+        assert item.deprecated_trigger_name == "LEGACY_TRIGGER"
+        assert item.trigger_config == {"canonical": True}
+        assert item.deprecated_trigger_config == {"legacy": True}
+        assert item.updated_at == "2026-07-29T00:00:00Z"
+        assert item.deprecated_updated_at == "2025-07-29T00:00:00Z"
+        assert item.disabled_at is None
+        assert item.deprecated_disabled_at == "2025-07-29T00:00:00Z"
+
+        serialized = item.to_dict(use_api_names=True)
+        assert serialized["connected_account_id"] == "ca_nanoid"
+        assert serialized["connected_account_uuid"] == "uuid-123"
+        assert serialized["connectedAccountId"] == "legacy-account-id"
+        assert serialized["trigger_name"] == "CANONICAL_TRIGGER"
+        assert serialized["triggerName"] == "LEGACY_TRIGGER"
+        assert serialized["trigger_config"] == {"canonical": True}
+        assert serialized["triggerConfig"] == {"legacy": True}
+        assert serialized["updated_at"] == "2026-07-29T00:00:00Z"
+        assert serialized["updatedAt"] == "2025-07-29T00:00:00Z"
+        assert serialized["disabled_at"] is None
+        assert serialized["disabledAt"] == "2025-07-29T00:00:00Z"
 
     @pytest.mark.skip(reason="no prism support for query param arrays")
     @parametrize


### PR DESCRIPTION
## Summary

- Add a Stainless OpenAPI transform that gives the five deprecated trigger-instance properties unique Python names while preserving their wire aliases.
- Regenerate the affected response model and add a distinct-value regression covering parsing and alias serialization.

## Verification

- `pytest -q tests/api_resources/test_trigger_instances.py::TestTriggerInstances::test_list_active_response_preserves_canonical_and_deprecated_fields`
- `ruff check src/composio_client/types/trigger_instance_list_active_response.py tests/api_resources/test_trigger_instances.py`
- `uv build`
